### PR TITLE
Implement a pass to simplify empty blocks

### DIFF
--- a/src/Semantics/Equiv.dfy
+++ b/src/Semantics/Equiv.dfy
@@ -826,8 +826,8 @@ module Bootstrap.Semantics.Equiv {
     if es == [] {}
     else {
        // Evaluate the first expression
-      var res0 := InterpExpr(es[0], env, ctx);
-      var res0' := InterpExpr(es[0], env, ctx');
+      var res0 := InterpExprWithType(es[0], Types.Unit, env, ctx);
+      var res0' := InterpExprWithType(es[0], Types.Unit, env, ctx');
       EqInterp_Refl(es[0]);
       EqInterp_Inst(es[0], es[0], env, ctx, ctx');
 
@@ -1052,8 +1052,8 @@ module Bootstrap.Semantics.Equiv {
     reveal InterpBlock_Exprs();
 
     // Evaluate the first expression
-    var res0 := InterpExpr(e, env, ctx);
-    var res0' := InterpExpr(e', env, ctx');
+    var res0 := InterpExprWithType(e, Types.Unit, env, ctx);
+    var res0' := InterpExprWithType(e', Types.Unit, env, ctx');
     EqInterp_Inst(e, e', env, ctx, ctx');
 
     // We need to make a case disjunction on whether the length of the concatenated sequences is


### PR DESCRIPTION
This PR implements a pass which does the following:

1. we filter the expressions which are empty blocks in blocks of expressions:
  ```
  var x := f();
  g();
  {
  // empty block
  }
  h();
  ...
     --->
  var x := f();
  g();
  h();
  ...
  ```

2. we inline the blocks which end blocks (note that we can't inline other blocks because of scoping issues):
  ```
  var x := f();
  {
    g();
    h();
  }
     --->
  var x := f();
  g();
  h();
  ```

3. We simplify the `if then else` expressions when their branches contain empty blocks:
  ```
  if b then {} else {} --> {} // if b is pure
  if b then {} else e --> if !b then e else {} // This allows us to only print `if !b then e` in the output program
  ```

In order to verify this pass, we introduced semantics for the interpretation of blocks. Those semantics are likely to evolve (see the comment for ``InterpBlock_Exprs``).