### PR TITLE
Improve the robustness of the translator

### DIFF
--- a/src/AST/Entities.dfy
+++ b/src/AST/Entities.dfy
@@ -42,7 +42,7 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
   datatype DataType =
     DataType()
   datatype NewType = // TODO: Change this into a subset type with a flag?
-    NewType(boundVar: string, ty: Types.Type, pred: Option<Expr>, witnessExpr: Option<Expr>)
+    NewType(boundVar: Option<string>, ty: Types.Type, pred: Option<Expr>, witnessExpr: Option<Expr>)
 
   datatype Type =
     | SubsetType(st: SubsetType)

--- a/src/AST/Entities.dfy
+++ b/src/AST/Entities.dfy
@@ -29,10 +29,10 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
     Import(localName: Atom, target: Name)
 
   datatype SubsetType =
-    SubsetType(boundVar: string, ty: Types.Type, pred: Expr, witnessExpr: Option<Expr>)
+    SubsetType(boundVar: string, ty: Types.Type, pred: Expr, witnessExpr: Option<Expr>, isNewType: bool)
 
   datatype TypeAlias =
-    TypeAlias(base: Types.Type)
+    TypeAlias(base: Types.Type, isNewType: bool)
   datatype AbstractType =
     AbstractType()
   datatype TraitType =
@@ -41,8 +41,6 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
     ClassType(parentTypes: seq<Name>)
   datatype DataType =
     DataType()
-  datatype NewType = // TODO: Change this into a subset type with a flag?
-    NewType(boundVar: Option<string>, ty: Types.Type, pred: Option<Expr>, witnessExpr: Option<Expr>)
 
   datatype Type =
     | SubsetType(st: SubsetType)
@@ -51,7 +49,6 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
     | TraitType(tt: TraitType)
     | ClassType(ct: ClassType)
     | DataType(dt: DataType)
-    | NewType(nt: NewType)
     | Unsupported(desc: string)
 
   datatype FieldKind =

--- a/src/AST/Translator.Entity.dfy
+++ b/src/AST/Translator.Entity.dfy
@@ -144,7 +144,7 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Translator.Entity {
   function TranslateNewtypeDecl(nt: C.NewtypeDecl): (e: TranslationResult<E.Type>)
     reads *
   {
-    var x := TypeConv.AsString(nt.Var.Name);
+    var x := if nt.Var == null then None else Some(TypeConv.AsString(nt.Var.Name));
     var ty :- Expr.TranslateType(nt.BaseType);
     var constraint :- Expr.TranslateOptionalExpression(nt.Constraint);
     var wit :- Expr.TranslateOptionalExpression(nt.Witness);

--- a/src/AST/Translator.Expressions.dfy
+++ b/src/AST/Translator.Expressions.dfy
@@ -344,9 +344,9 @@ module Bootstrap.AST.Translator.Expressions {
     var ty :- TranslateType(se.Seq.Type);
     :- Need(se.SelectOne ==> se.E0 != null && se.E1 == null,
         Invalid("Inconsistent values for `SelectOne` and E1 in SeqSelect."));
-    :- Need(!se.SelectOne ==> ty.Collection? && ty.kind.Seq?,
-        Invalid("`SeqSelect` on a map or multiset must have a single index."));
-    if !ty.Collection?  || ty.kind.Set? then
+    if || !ty.Collection? 
+       || ty.kind.Set? 
+       || (!se.SelectOne && (!ty.Collection? || !ty.kind.Seq?)) then
       TranslateUnsupportedExpression(se)
     else
       assume Math.Max(ASTHeight(se.Seq), Math.Max(ASTHeight(se.E0), ASTHeight(se.E1))) < ASTHeight(se);

--- a/src/AST/Translator.Expressions.dfy
+++ b/src/AST/Translator.Expressions.dfy
@@ -340,44 +340,44 @@ module Bootstrap.AST.Translator.Expressions {
 
   function method TranslateSeqSelectExpr(se: C.SeqSelectExpr): (e: TranslationResult<DE.T>)
     reads *
-    decreases ASTHeight(se), 0
+    decreases ASTHeight(se), 1
     ensures e.Success? ==> P.All_Expr(e.value, DE.WellFormed)
   { // FIXME: The models that we generate do not allow for `null`
     var ty :- TranslateType(se.Seq.Type);
-    :- Need(ty.Collection? && !ty.kind.Set?,
-            Invalid("`SeqSelect` must be on a map, sequence, or multiset."));
-    :- Need(se.SelectOne ==> se.E0 != null && se.E1 == null,
-            Invalid("Inconsistent values for `SelectOne` and E1 in SeqSelect."));
-    :- Need(!se.SelectOne ==> ty.kind.Seq?,
-            Invalid("`SeqSelect` on a map or multiset must have a single index."));
-    assume Math.Max(ASTHeight(se.Seq), Math.Max(ASTHeight(se.E0), ASTHeight(se.E1))) < ASTHeight(se);
-    var recv :- TranslateExpression(se.Seq);
-    var eager := (op, args) => Success(DE.Apply(DE.Eager(op), args));
-    match ty.kind { // FIXME AST gen should produce `Expression?` not `Expression`
-      case Seq() =>
-        if se.SelectOne then
-          assert se.E1 == null;
+    if ( || !ty.Collection?
+         || ty.kind.Set?
+         || (se.SelectOne && (se.E0 == null || se.E1 != null))
+         || (!se.SelectOne && ty.Collection? && !ty.kind.Seq?)) then
+      TranslateUnsupportedExpression(se)
+    else
+      assume Math.Max(ASTHeight(se.Seq), Math.Max(ASTHeight(se.E0), ASTHeight(se.E1))) < ASTHeight(se);
+      var recv :- TranslateExpression(se.Seq);
+      var eager := (op, args) => Success(DE.Apply(DE.Eager(op), args));
+      match ty.kind { // FIXME AST gen should produce `Expression?` not `Expression`
+        case Seq() =>
+          if se.SelectOne then
+            assert se.E1 == null;
+            var e0 :- TranslateExpression(se.E0);
+            eager(DE.BinaryOp(DE.BinaryOps.Sequences(DE.BinaryOps.SeqSelect)), [recv, e0])
+          else if se.E1 == null then
+            var e0 :- TranslateExpression(se.E0);
+            eager(DE.BinaryOp(DE.BinaryOps.Sequences(DE.BinaryOps.SeqDrop)), [recv, e0])
+          else if se.E0 == null then
+            var e1 :- TranslateExpression(se.E1);
+            eager(DE.BinaryOp(DE.BinaryOps.Sequences(DE.BinaryOps.SeqTake)), [recv, e1])
+          else
+            var e0 :- TranslateExpression(se.E0);
+            var e1 :- TranslateExpression(se.E1);
+            eager(DE.TernaryOp(DE.TernaryOps.Sequences(DE.TernaryOps.SeqSubseq)), [recv, e0, e1])
+        case Map(_) =>
+          assert se.SelectOne && se.E1 == null;
           var e0 :- TranslateExpression(se.E0);
-          eager(DE.BinaryOp(DE.BinaryOps.Sequences(DE.BinaryOps.SeqSelect)), [recv, e0])
-        else if se.E1 == null then
+          eager(DE.BinaryOp(DE.BinaryOps.Maps(DE.BinaryOps.MapSelect)), [recv, e0])
+        case Multiset() =>
+          assert se.SelectOne && se.E1 == null;
           var e0 :- TranslateExpression(se.E0);
-          eager(DE.BinaryOp(DE.BinaryOps.Sequences(DE.BinaryOps.SeqDrop)), [recv, e0])
-        else if se.E0 == null then
-          var e1 :- TranslateExpression(se.E1);
-          eager(DE.BinaryOp(DE.BinaryOps.Sequences(DE.BinaryOps.SeqTake)), [recv, e1])
-        else
-          var e0 :- TranslateExpression(se.E0);
-          var e1 :- TranslateExpression(se.E1);
-          eager(DE.TernaryOp(DE.TernaryOps.Sequences(DE.TernaryOps.SeqSubseq)), [recv, e0, e1])
-      case Map(_) =>
-        assert se.SelectOne && se.E1 == null;
-        var e0 :- TranslateExpression(se.E0);
-        eager(DE.BinaryOp(DE.BinaryOps.Maps(DE.BinaryOps.MapSelect)), [recv, e0])
-      case Multiset() =>
-        assert se.SelectOne && se.E1 == null;
-        var e0 :- TranslateExpression(se.E0);
-        eager(DE.BinaryOp(DE.BinaryOps.Multisets(DE.BinaryOps.MultisetSelect)), [recv, e0])
-    }
+          eager(DE.BinaryOp(DE.BinaryOps.Multisets(DE.BinaryOps.MultisetSelect)), [recv, e0])
+      }
   }
 
   function method TranslateSeqUpdateExpr(se: C.SeqUpdateExpr)

--- a/src/AST/Translator.Expressions.dfy
+++ b/src/AST/Translator.Expressions.dfy
@@ -503,10 +503,13 @@ module Bootstrap.AST.Translator.Expressions {
     reads *
     decreases ASTHeight(ue), 0
   {
-    var children := EnumerableUtils.ToSeq(ue.SubExpressions);
-    var children' :- Seq.MapResult(children, e requires e in children reads * =>
-      assume Decreases(e, ue); TranslateExpression(e));
-    Success(DE.Unsupported("Unsupported expression", children'))
+    if ue == null then
+      Success(DE.Unsupported("Unsupported expression: null", []))
+    else
+      var children := if ue.SubExpressions == null then [] else EnumerableUtils.ToSeq(ue.SubExpressions);
+      var children' :- Seq.MapResult(children, e requires e in children reads * =>
+        assume Decreases(e, ue); TranslateExpression(e));
+      Success(DE.Unsupported("Unsupported expression", children'))
   }
 
   // TODO: adapt auto-generated AST to include some nullable fields
@@ -599,13 +602,16 @@ module Bootstrap.AST.Translator.Expressions {
     reads *
     decreases ASTHeight(us), 0
   {
-    var subexprs := EnumerableUtils.ToSeq(us.SubExpressions);
-    var substmts := EnumerableUtils.ToSeq(us.SubStatements);
-    var subexprs' :- Seq.MapResult(subexprs, e requires e in subexprs reads * =>
-      assume Decreases(e, us); TranslateExpression(e));
-    var substmts' :- Seq.MapResult(substmts, s requires s in substmts reads * =>
-      assume Decreases(s, us); TranslateStatement(s));
-    Success(DE.Unsupported("Unsupported expression", subexprs' + substmts'))
+    if us == null then
+      Success(DE.Unsupported("Unsupporte statement: null", []))
+    else
+      var subexprs := EnumerableUtils.ToSeq(us.SubExpressions);
+      var substmts := EnumerableUtils.ToSeq(us.SubStatements);
+      var subexprs' :- Seq.MapResult(subexprs, e requires e in subexprs reads * =>
+        assume Decreases(e, us); TranslateExpression(e));
+      var substmts' :- Seq.MapResult(substmts, s requires s in substmts reads * =>
+        assume Decreases(s, us); TranslateStatement(s));
+      Success(DE.Unsupported("Unsupported statement", subexprs' + substmts'))
   }
 
 

--- a/src/AST/Translator.Expressions.dfy
+++ b/src/AST/Translator.Expressions.dfy
@@ -301,11 +301,13 @@ module Bootstrap.AST.Translator.Expressions {
     decreases ASTHeight(de), 0
   {
     var ty :- TranslateType(de.Type);
-    :- Need(ty.Collection? && ty.finite, Invalid("`DisplayExpr` must be a finite collection."));
     var elems := ListUtils.ToSeq(de.Elements);
     var elems :- Seq.MapResult(elems, e requires e in elems reads * =>
       assume Decreases(e, de); TranslateExpression(e));
-    Success(DE.Apply(DE.Eager(DE.Builtin(DE.Display(ty))), elems))
+    if !ty.Collection? || (ty.Collection? && !ty.finite) then
+      Success(DE.Unsupported("`DisplayExpr` must be a finite collection.", elems))
+    else
+      Success(DE.Apply(DE.Eager(DE.Builtin(DE.Display(ty))), elems))
   }
 
   function method TranslateExpressionPair(mde: C.MapDisplayExpr, ep: C.ExpressionPair)

--- a/src/AST/Translator.Expressions.dfy
+++ b/src/AST/Translator.Expressions.dfy
@@ -217,11 +217,13 @@ module Bootstrap.AST.Translator.Expressions {
     else if l.Value is BaseTypes.BigDec then
       Success(DE.Literal(DE.LitReal(TypeConv.AsReal(l.Value)))) // TODO test
     else if l.Value is String then
-      var str := TypeConv.AsString(l.Value);
       if l is C.CharLiteralExpr then
-        :- Need(|str| == 1, Invalid("CharLiteralExpr must contain a single character."));
-        Success(DE.Literal(DE.LitChar(str[0])))
+        var charEnum := ExprUtils.UnescapedCharacters(l as C.CharLiteralExpr);
+        var chars := EnumerableUtils.ToSeq(charEnum);
+        :- Need(|chars| == 1, Invalid("CharLiteralExpr must contain a single character."));
+        Success(DE.Literal(DE.LitChar(chars[0])))
       else if l is C.StringLiteralExpr then
+        var str := TypeConv.AsString(l.Value);
         var sl := l as C.StringLiteralExpr;
         Success(DE.Literal(DE.LitString(str, sl.IsVerbatim)))
       else

--- a/src/AST/Translator.Expressions.dfy
+++ b/src/AST/Translator.Expressions.dfy
@@ -417,9 +417,8 @@ module Bootstrap.AST.Translator.Expressions {
     decreases ASTHeight(le), 0
   {
     var lhss := ListUtils.ToSeq(le.LHSs);
-    var bvs :- Seq.MapResult(lhss, (pat: C.CasePattern<C.BoundVar>) reads * =>
-      :- Need(pat.Var != null, Invalid("Null pattern variable in let expression."));
-      Success(TypeConv.AsString(pat.Var.Name)));
+    var bvs := Seq.Map((pat: C.CasePattern<C.BoundVar>) reads * =>
+      if pat.Var == null then "_" else TypeConv.AsString(pat.Var.Name), lhss);
     var rhss := ListUtils.ToSeq(le.RHSs);
     var elems :- Seq.MapResult(rhss, e requires e in rhss reads * =>
       assume Decreases(e, le); TranslateExpression(e));

--- a/src/Interop/CSharpDafnyASTInterop.cs
+++ b/src/Interop/CSharpDafnyASTInterop.cs
@@ -4,7 +4,7 @@ namespace CSharpDafnyASTInterop {
       ty.NormalizeExpand();
   }
   public partial class ExprUtils {
-    public static IEnumerable<char> UnescapedCharacters(Microsoft.Dafny.CharLiteralExpr e) =>
-      Microsoft.Dafny.Util.UnescapedCharacters((string)e.Value, false);
+    public static List<char> UnescapedCharacters(Microsoft.Dafny.LiteralExpr e) =>
+      Microsoft.Dafny.Util.UnescapedCharacters((string)e.Value, false).ToList();
   }
 }

--- a/src/Interop/CSharpDafnyASTInterop.cs
+++ b/src/Interop/CSharpDafnyASTInterop.cs
@@ -3,4 +3,8 @@ namespace CSharpDafnyASTInterop {
     public static Microsoft.Dafny.Type NormalizeExpand(Microsoft.Dafny.Type ty) =>
       ty.NormalizeExpand();
   }
+  public partial class ExprUtils {
+    public static IEnumerable<char> UnescapedCharacters(Microsoft.Dafny.CharLiteralExpr e) =>
+      Microsoft.Dafny.Util.UnescapedCharacters((string)e.Value, false);
+  }
 }

--- a/src/Interop/CSharpDafnyASTInterop.dfy
+++ b/src/Interop/CSharpDafnyASTInterop.dfy
@@ -12,7 +12,7 @@ module {:extern "CSharpDafnyASTInterop"} Bootstrap.Interop.CSharpDafnyASTInterop
     requires || c is CSharpDafnyASTModel.Expression
              || c is CSharpDafnyASTModel.Statement
              || c is CSharpDafnyASTModel.Declaration
-             || c is CSharpDafnyASTModel.ModuleSignature
+             || c is CSharpDafnyASTModel.ModuleDefinition
              || c is CSharpDafnyASTModel.Attributes
 
   class {:extern} TypeUtils {

--- a/src/Interop/CSharpDafnyASTInterop.dfy
+++ b/src/Interop/CSharpDafnyASTInterop.dfy
@@ -26,7 +26,9 @@ module {:extern "CSharpDafnyASTInterop"} Bootstrap.Interop.CSharpDafnyASTInterop
   class {:extern} ExprUtils {
     constructor {:extern} () requires false // Prevent instantiation
 
-    static function method {:extern} UnescapedCharacters(ty: CSharpDafnyASTModel.CharLiteralExpr)
-      : (cs: IEnumerable<char>)
+    static function method {:extern} UnescapedCharacters(e: CSharpDafnyASTModel.LiteralExpr)
+      : (cs: List<char>)
+      reads e
+      requires e.Value is System.String
   }
 }

--- a/src/Interop/CSharpDafnyASTInterop.dfy
+++ b/src/Interop/CSharpDafnyASTInterop.dfy
@@ -1,7 +1,10 @@
 include "CSharpDafnyASTModel.dfy"
+include "CSharpModel.dfy"
 
 module {:extern "CSharpDafnyASTInterop"} Bootstrap.Interop.CSharpDafnyASTInterop {
   import CSharpDafnyASTModel
+  import System
+  import opened System.Collections.Generic
 
   function {:axiom} TypeHeight(t: CSharpDafnyASTModel.Type) : nat
 
@@ -18,5 +21,12 @@ module {:extern "CSharpDafnyASTInterop"} Bootstrap.Interop.CSharpDafnyASTInterop
     static function method {:extern} NormalizeExpand(ty: CSharpDafnyASTModel.Type)
       : (ty': CSharpDafnyASTModel.Type)
       ensures TypeHeight(ty') <= TypeHeight(ty)
+  }
+
+  class {:extern} ExprUtils {
+    constructor {:extern} () requires false // Prevent instantiation
+
+    static function method {:extern} UnescapedCharacters(ty: CSharpDafnyASTModel.CharLiteralExpr)
+      : (cs: IEnumerable<char>)
   }
 }

--- a/src/Interop/CSharpInterop.cs
+++ b/src/Interop/CSharpInterop.cs
@@ -39,21 +39,4 @@ namespace CSharpInterop {
       return b0;
     }
   }
-
-  public partial class DictUtils {
-    public static R FoldL<K, V, R>(Func<R, K, V, R> f, R r0, Dictionary<K, V>? d) where K : notnull {
-      if(d is null) {
-        return r0;
-      }
-      var keys = d.Keys.ToList();
-      // The keys really should be sorted to make this a valid `function`
-      // in Dafny, but some of the instances that come up in practice have
-      // key types that don't implement `IComparable`. *sigh*
-      //keys.Sort();
-      foreach (var k in keys) {
-        r0 = f(r0, k, d[k]);
-      }
-      return r0;
-    }
-  }
 }

--- a/src/Interop/CSharpInterop.cs
+++ b/src/Interop/CSharpInterop.cs
@@ -46,7 +46,10 @@ namespace CSharpInterop {
         return r0;
       }
       var keys = d.Keys.ToList();
-      keys.Sort();
+      // The keys really should be sorted to make this a valid `function`
+      // in Dafny, but some of the instances that come up in practice have
+      // key types that don't implement `IComparable`. *sigh*
+      //keys.Sort();
       foreach (var k in keys) {
         r0 = f(r0, k, d[k]);
       }

--- a/src/Interop/CSharpInterop.dfy
+++ b/src/Interop/CSharpInterop.dfy
@@ -40,21 +40,4 @@ module {:extern "CSharpInterop"} Bootstrap.Interop.CSharpInterop {
       FoldR((t, s) => [t] + s, [], l)
     }
   }
-
-  class DictUtils {
-    constructor {:extern} () requires false // Prevent instantiation
-
-    static function method {:extern} FoldL<K, V, R>(f: (R, K, V) -> R, r0: R, d: Dictionary<K, V>): R
-      reads d
-
-    static function method ReduceSeq<K, V>(acc: seq<(K, V)>, key: K, value: V): seq<(K, V)> {
-      acc + [(key, value)]
-    }
-
-    static function method DictionaryToSeq<K, V>(d: Dictionary<K, V>): seq<(K, V)>
-      reads d
-    {
-      FoldL(ReduceSeq, [], d)
-    }
-  }
 }

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -44,9 +44,7 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
     TagIf(exists a | a in e.ei.attrs :: a.name == Extern, HasExternAttribute) +
     TagIf(exists a | a in e.ei.attrs :: a.name == Axiom, HasAxiomAttribute) +
     TagIf(e.Type? && e.t.SubsetType?, IsSubsetType) +
-    TagIf(e.Type? && e.t.NewType? && e.t.nt.pred.Some?, IsSubsetType) +
     TagIf(e.Type? && e.t.SubsetType? && e.t.st.witnessExpr.None?, MissingWitness) +
-    TagIf(e.Type? && e.t.NewType? && e.t.nt.witnessExpr.None?, MissingWitness) +
     TagIf(e.Definition? && e.d.Callable? && e.d.ci.body.None?, MissingBody) +
     TagIf(e.Definition? && e.d.Callable? && e.d.ci.body.Some? &&
           ContainsAssumeStatement(e.d.ci.body.value), HasAssumeInBody) +


### PR DESCRIPTION
Some constructs that appear in practice previously caused the C# -> Dafny AST translator to crash or return `Invalid`. These now result in `Unsupported` or are handled by changes to the AST itself.