### PR TITLE
Improve auditor output

### DIFF
--- a/src/AST/Entities.dfy
+++ b/src/AST/Entities.dfy
@@ -3,6 +3,7 @@
 
 include "Names.dfy"
 include "Syntax.dfy"
+include "../Interop/CSharpInterop.dfy"
 include "../Utils/Library.dfy"
 include "../Utils/Lib.Sort.dfy"
 
@@ -10,6 +11,7 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
   // Hierarchies of Dafny entities.
   // See </doc/design/entities.md>.
 {
+  import opened Interop.CSharpInterop
   import opened Names
   import opened Syntax.Exprs
   import opened Syntax.Types
@@ -79,6 +81,10 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
   {
     static function EMPTY(): Location {
       Location("<none>", 0, 0)
+    }
+
+    function ToString(): string {
+      file + "(" + NumUtils.IntToString(line) + "," + NumUtils.IntToString(column) + ")"
     }
   }
 

--- a/src/AST/Names.dfy
+++ b/src/AST/Names.dfy
@@ -44,6 +44,15 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
       }
     }
 
+    function IsCompile(): bool {
+      match this {
+        case Anonymous => false
+        case Name(_, suffix) =>
+          var parts := Seq.Split('_', suffix);
+          (|parts| > 0 && parts[|parts| - 1] == "Compile") || parent.IsCompile()
+      }
+    }
+
     function ToSeq(): seq<Atom> {
       match this
         case Anonymous => []

--- a/src/AST/Names.dfy
+++ b/src/AST/Names.dfy
@@ -36,10 +36,11 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
 
     function IsInternal(): bool {
       match this {
-        case Anonymous => true
-        case Name(_, suffix) =>
+        case Anonymous => false
+        case Name(Anonymous, "_System") => true
+        case Name(parent, suffix) =>
           var parts := Seq.Split('_', suffix);
-          |parts| > 0 && parts[0] == "reveal"
+          (|parts| > 0 && parts[0] == "reveal") || parent.IsInternal()
       }
     }
 

--- a/src/AST/Names.dfy
+++ b/src/AST/Names.dfy
@@ -1,6 +1,7 @@
 include "../Utils/Library.dfy"
 
 module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
+  import Utils.Lib.Seq
   import Utils.Lib.Set
   import C = Utils.Lib.Sort.Comparison
   import SeqCmp = Utils.Lib.Seq.Comparison
@@ -26,6 +27,20 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
         case Anonymous => "_"
         case Name(Anonymous, suffix) => suffix
         case Name(parent, suffix) => parent.ToString() + "." + suffix
+    }
+
+    function ToDafnyName(): string {
+      var parts := Seq.Filter(this.ToSeq(), a => a !in {"_default", "_module"});
+      Seq.Flatten(Seq.Interleave(".", parts))
+    }
+
+    function IsInternal(): bool {
+      match this {
+        case Anonymous => true
+        case Name(_, suffix) =>
+          var parts := Seq.Split('_', suffix);
+          |parts| > 0 && parts[0] == "reveal"
+      }
     }
 
     function ToSeq(): seq<Atom> {

--- a/src/Interop/CSharpAuditorInterop.dfy
+++ b/src/Interop/CSharpAuditorInterop.dfy
@@ -1,0 +1,12 @@
+include "CSharpDafnyInterop.dfy"
+include "CSharpInterop.dfy"
+
+module {:extern "Microsoft.Dafny.Compilers.SelfHosting.Auditor"} {:compile false} Bootstrap.Tools.AuditorExterns {
+  import System
+  import Microsoft
+
+  class {:compile false} Auditor {
+    static method {:extern} Error(reporter: Microsoft.Dafny.ErrorReporter, file: System.String, line: System.int32, col: System.int32, msg: System.String)
+    static method {:extern} Warning(reporter: Microsoft.Dafny.ErrorReporter, file: System.String, line: System.int32, col: System.int32, msg: System.String)
+  }
+}

--- a/src/Interop/CSharpInterop.cs
+++ b/src/Interop/CSharpInterop.cs
@@ -1,5 +1,8 @@
 #nullable enable
 using System.Numerics;
+using Dafny;
+using icharseq = Dafny.ISequence<char>;
+using charseq = Dafny.Sequence<char>;
 
 namespace CSharpInterop {
   public partial class ListUtils {
@@ -37,6 +40,12 @@ namespace CSharpInterop {
         b0 = f(x, b0);
       }
       return b0;
+    }
+  }
+
+  public partial class NumUtils {
+    public static icharseq IntToString(BigInteger n) {
+      return charseq.FromString(n.ToString());
     }
   }
 }

--- a/src/Interop/CSharpInterop.dfy
+++ b/src/Interop/CSharpInterop.dfy
@@ -45,5 +45,9 @@ module {:extern "CSharpInterop"} Bootstrap.Interop.CSharpInterop {
     constructor {:extern} () requires false // Prevent instantiation
 
     static function method {:extern} IntToString(x: int): string
+
+    static function method AsInt32OrNegOne(x: int): System.int32 {
+      (if -0x8000_0000 <= x < 0x8000_0000 then x else -1) as System.int32
+    }
   }
 }

--- a/src/Interop/CSharpInterop.dfy
+++ b/src/Interop/CSharpInterop.dfy
@@ -40,4 +40,10 @@ module {:extern "CSharpInterop"} Bootstrap.Interop.CSharpInterop {
       FoldR((t, s) => [t] + s, [], l)
     }
   }
+
+  class NumUtils {
+    constructor {:extern} () requires false // Prevent instantiation
+
+    static function method {:extern} IntToString(x: int): string
+  }
 }

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -58,7 +58,7 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
   function AddAssumptions(e: Entity, assms: seq<Assumption>): seq<Assumption> {
     var tags := GetTags(e);
     if IsAssumption(tags) then
-      assms + [Assumption(e.ei.name.ToDafnyName(), tags)]
+      assms + [Assumption(e.ei.name.ToDafnyName(), e.ei.location, tags)]
     else
       assms
   }

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -78,7 +78,7 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
 
     method Audit(render: Report -> string, p: CSharpDafnyASTModel.Program) returns (r: string)
     {
-      var res := E.TranslateProgram(p);
+      var res := E.TranslateProgram(p, true);
       match res {
         case Success(p') =>
           var rpt := GenerateAuditReport(p'.registry);

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -58,13 +58,13 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
   function AddAssumptions(e: Entity, assms: seq<Assumption>): seq<Assumption> {
     var tags := GetTags(e);
     if IsAssumption(tags) then
-      assms + [Assumption(e.ei.name.ToString(), tags)]
+      assms + [Assumption(e.ei.name.ToDafnyName(), tags)]
     else
       assms
   }
 
   function FoldEntities<T(!new)>(f: (Entity, T) -> T, reg: Registry_, init: T): T {
-    var names := reg.SortedNames();
+    var names := Seq.Filter(reg.SortedNames(), (n:Name) => !n.IsInternal());
     FoldL((a, n) requires reg.Contains(n) => f(reg.Get(n), a), init, names)
   }
 

--- a/src/Tools/Auditor/EntryPoint.cs
+++ b/src/Tools/Auditor/EntryPoint.cs
@@ -35,6 +35,25 @@ public class Auditor : Plugins.Rewriter {
     return templateText.Replace("{{TABLE}}", table.ToString());
   }
 
+  // TODO: potentially move this to ErrorReporter as a non-static method
+  internal static void Warning(ErrorReporter reporter, string filename, int line, int col, string msg) {
+    var tok = new Token(line, col);
+    tok.Filename = filename;
+    // TODO: is this the right source? This is technically a rewriter
+    // plugin, but it's not doing any rewriting. Maybe we should add
+    // support for resolver plugins and change this to be one?
+    reporter.Warning(MessageSource.Rewriter, tok, msg);
+  }
+
+  internal static void Error(ErrorReporter reporter, string filename, int line, int col, string msg) {
+    var tok = new Token(line, col);
+    tok.Filename = filename;
+    // TODO: is this the right source? This is technically a rewriter
+    // plugin, but it's not doing any rewriting. Maybe we should add
+    // support for resolver plugins and change this to be one?
+    reporter.Error(MessageSource.Rewriter, tok, msg);
+  }
+
   public override void PostResolve(Program program) {
     string? filename = null;
     Format format = Format.Text;
@@ -58,15 +77,15 @@ public class Auditor : Plugins.Rewriter {
       }
     }
 
-    var text = format switch {
-      Format.HTML => GenerateHTMLReport(program),
-      Format.Markdown => auditor.AuditMarkdown(program).ToString(),
-      Format.Text => auditor.AuditText(program).ToString(),
-    };
-
     if (filename is null) {
-      Console.WriteLine(text);
+      auditor.AuditWarnings(Reporter, program);
     } else {
+      var text = format switch {
+        Format.HTML => GenerateHTMLReport(program),
+        Format.Markdown => auditor.AuditMarkdown(program).ToString(),
+        Format.Text => auditor.AuditText(program).ToString(),
+      };
+
       File.WriteAllText(filename, text);
     }
   }

--- a/src/Tools/Auditor/EntryPoint.cs
+++ b/src/Tools/Auditor/EntryPoint.cs
@@ -37,7 +37,7 @@ public class Auditor : Plugins.Rewriter {
 
   public override void PostResolve(Program program) {
     string? filename = null;
-    Format format = Format.Markdown;
+    Format format = Format.Text;
     string[] args = AuditorConfiguration.args;
 
     if (args.Count() > 1) {

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -78,34 +78,33 @@ module Bootstrap.Tools.AuditReport {
      if b then [elt] else []
   }
 
-  // TODO: improve these descriptions
   function method AssumptionDescription(ts: set<Tag>): seq<(string, string)> {
     MaybeElt(IsCallable in ts && MissingBody in ts && IsGhost in ts,
-      ("Function or lemma has no body.",
-       "Provide a body or add {:axiom}.")) +
+      ("Ghost declaration has no body.",
+       "Provide a body or add `{:axiom}`.")) +
     MaybeElt(IsCallable in ts && MissingBody in ts && !(IsGhost in ts),
-      ("Callable definition has no body.",
-       "Provide a body or add {:axiom}.")) +
+      ("Compiled declaration has no body.",
+       "Provide a body or add `{:axiom}`.")) +
     MaybeElt(HasExternAttribute in ts && HasRequiresClause in ts,
-      ("Extern symbol with precondition.",
+      ("Declaration with `{:extern}` has precondition.",
        "Extensively test client code.")) +
     MaybeElt(HasExternAttribute in ts && HasEnsuresClause in ts,
-      ("Extern symbol with postcondition.",
-       "Provide a model or a test case, or both.")) +
+      ("Declaration with `{:extern}` has postcondition.",
+       "Extensively test against external code.")) +
        /*
     MaybeElt(IsSubsetType in ts && MissingWitness in ts,
       ("Subset type has no witness and could be empty.",
        "Provide a witness.")) +
        */
     MaybeElt(HasAxiomAttribute in ts,
-      ("Has explicit `{:axiom}` attribute.",
-       "Attempt to provide a proof or model.")) +
+      ("Declaration has explicit `{:axiom}` attribute.",
+       "Attempt to provide a proof or test.")) +
     MaybeElt(MayNotTerminate in ts,
-      ("May not terminate (uses `decreases *`).",
+      ("Method may not terminate (uses `decreases *`).",
        "Provide a valid `decreases` clause.")) +
     MaybeElt(HasAssumeInBody in ts,
-      ("Has `assume` statement in body.",
-      "Try to replace with `assert` and prove or add {:axiom}."))
+      ("Definition has `assume` statement in body.",
+      "Try to replace with `assert` and prove or add `{:axiom}`."))
   }
 
   lemma AllAssumptionsDescribed(ts: set<Tag>)

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -1,6 +1,8 @@
+include "../../AST/Entities.dfy"
 include "../../Utils/Library.dfy"
 
-module AuditReport {
+module Bootstrap.Tools.AuditReport {
+  import opened AST.Entities
   import opened Utils.Lib.Seq
 
 /// ## Data types for report
@@ -40,7 +42,7 @@ module AuditReport {
     }
 
   datatype Assumption =
-    Assumption(name: string, tags: set<Tag>)
+    Assumption(name: string, location: Location, tags: set<Tag>)
 
   datatype Report =
     Report(assumptions: seq<Assumption>)

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -5,7 +5,7 @@ module Bootstrap.Tools.AuditReport {
   import opened AST.Entities
   import opened Utils.Lib.Seq
 
-/// ## Data types for report
+  /// ## Data types for report
 
   datatype Tag =
     | IsGhost
@@ -49,7 +49,7 @@ module Bootstrap.Tools.AuditReport {
 
   const EmptyReport := Report([])
 
-/// ## Tag categorization
+  /// ## Tag categorization
 
   predicate method IsAssumption(ts: set<Tag>) {
     // This seems to be of little value at the moment
@@ -68,7 +68,7 @@ module Bootstrap.Tools.AuditReport {
     || HasAssumeInBody in ts
   }
 
-/// ## Report rendering
+  /// ## Report rendering
 
   function method BoolYN(b: bool): string {
     if b then "Y" else "N"

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -156,10 +156,13 @@ module Bootstrap.Tools.AuditReport {
     FoldL((s, a) => s + RenderAssumptionHTML(a) + "\n", header, r.assumptions)
   }
 
+  function method AssumptionWarning(a: Assumption, desc: (string, string)): string {
+      a.location.ToString() + ": " + a.name + ": " + desc.0 + " Possible mitigation: " + desc.1
+  }
+
   function method RenderAssumptionText(a: Assumption): string {
     var descs := AssumptionDescription(a.tags);
-    var lines := Map((desc: (string, string)) =>
-      a.location.ToString() + ": " + a.name + ": " + desc.0 + " Possible mitigation: " + desc.1, descs);
+    var lines := Map((desc: (string, string)) => AssumptionWarning(a, desc), descs);
     Flatten(Seq.Interleave("\n", lines))
   }
 

--- a/src/Tools/Auditor/ReportTest.dfy
+++ b/src/Tools/Auditor/ReportTest.dfy
@@ -7,19 +7,21 @@ module AuditReportTest {
   method Main() {
     var rpt := Report([
       Assumption("MinusBv8NoBody",
-        {IsCallable, IsGhost, HasNoBody, HasEnsuresClause}),
+        {IsCallable, IsGhost, MissingBody, HasEnsuresClause}),
       Assumption("LeftShiftBV128",
-        {IsCallable, IsGhost, HasNoBody, HasEnsuresClause, HasAxiomAttribute}),
+        {IsCallable, IsGhost, MissingBody, HasEnsuresClause, HasAxiomAttribute}),
       Assumption("MinusBv8Assume",
         {IsCallable, IsGhost, HasEnsuresClause, HasAssumeInBody}),
       Assumption("GenerateBytes",
-        {IsCallable, HasExternAttribute, HasEnsuresClause, HasNoBody}),
+        {IsCallable, HasExternAttribute, HasEnsuresClause, MissingBody}),
       Assumption("GenerateBytesWithModel",
         {IsCallable, HasExternAttribute, HasEnsuresClause}),
       Assumption("GenerateBytesWrapper",
-        {IsCallable, HasExternAttribute, HasEnsuresClause, HasAssumeInBody}),
+        {IsCallable, HasExternAttribute, HasEnsuresClause, HasAssumeInBody})
+      /*
       Assumption("emptyType",
-        {IsSubsetType, HasNoWitness})
+        {IsSubsetType, MissingWitness})
+        */
       // This doesn't pass IsAsssumption
       /*
       Assumption("WhoKnows",

--- a/src/Tools/Auditor/assets/template.html
+++ b/src/Tools/Auditor/assets/template.html
@@ -17,6 +17,9 @@
       vertical-align: middle;
     }
     .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+    table tr:nth-child(odd) td {
+      background-color: #BBBBBB;
+    }
   </style>
   <link rel="stylesheet" href="assets/style.css" />
 </head>


### PR DESCRIPTION
This PR makes various changes to the auditor output, including:

* Skipping included modules, `_Compile` modules, and internal names
* Formatting names more readably
* Using one row per issue in tables (rather than one row per name)
* Supporting warning-like output (used when no file name is specified)
* Improving the text of some issue descriptions
* Coloring alternate table rows differently in the HTML output

Fixes #19