### PR TITLE
Add documentation to auditor and improve output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,15 @@ Supported language
 Our initial target is the purely functional subset of Dafny (aka non-ghost functions).  This is also the subset that the compiler is written on (our first large application will be bootstrapping the compiler itself).
 The Dafny-in-Dafny AST is defined in ``src/AST.dfy``.  We have operational semantics for most of it in ``src/Semantics/Interp.dfy``.  The C# backend is in ``src/Backends/CSharp/Compiler.dfy``, but it is not up-to-date (we are focusing on the language and the semantics).
 
+Tools
+-----
+
+The Dafny in Dafny code base supports two key executable programs:
+
+* A REPL, for interactively evaluating Dafny statements, in ``src/REPL``.
+
+* An auditor plugin, for reporting assumptions in a Dafny program, in ``src/Tools/Auditor``.
+
 Design notes
 ------------
 
@@ -91,6 +100,14 @@ Project hierarchy
       Extern declarations for existing C# functions from Dafny's codebase
     ``CSharpModel.dfy``
       Extern declarations for C#'s standard library (automatically copied from ``AutoExtern``)
+  ``Tools/``
+    ``Auditor/``
+      ``Auditor.dfy``
+      An auditor to identify assumptions in a Dafny program.
+      ``EntryPoint.cs``
+      The C# entry point that enables the auditor to be used as a plugin from Dafny.
+      ``Report.dfy``
+      The ``Report`` data structure used by the auditor.
   ``Utils/``
     ``Library.dfy``
       Utility functions (should move to shared library)

--- a/src/AST/Entities.dfy
+++ b/src/AST/Entities.dfy
@@ -3,6 +3,7 @@
 
 include "Names.dfy"
 include "Syntax.dfy"
+include "../Interop/CSharpInterop.dfy"
 include "../Utils/Library.dfy"
 include "../Utils/Lib.Sort.dfy"
 
@@ -10,6 +11,7 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
   // Hierarchies of Dafny entities.
   // See </doc/design/entities.md>.
 {
+  import opened Interop.CSharpInterop
   import opened Names
   import opened Syntax.Exprs
   import opened Syntax.Types
@@ -79,6 +81,10 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
   {
     static function EMPTY(): Location {
       Location("<none>", 0, 0)
+    }
+
+    function ToString(): string {
+      file + "(" + NumUtils.IntToString(line) + "," + NumUtils.IntToString(column) + ")"
     }
   }
 

--- a/src/AST/Entities.dfy
+++ b/src/AST/Entities.dfy
@@ -15,8 +15,10 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
   import opened Names
   import opened Syntax.Exprs
   import opened Syntax.Types
+  import System
   import opened Utils.Lib.Datatypes
   import Utils.Lib.SetSort
+  import Utils.Lib.Str
   import OS = Utils.Lib.Outcome.OfSeq
 
   // DISCUSS: Should this module be parameterized by `TExpr`?
@@ -77,14 +79,14 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Entities
     | EUnsupported
 
   datatype Location =
-    Location(file: string, line: int, column: int)
+    Location(file: string, line: System.int32, column: System.int32)
   {
     static function EMPTY(): Location {
       Location("<none>", 0, 0)
     }
 
     function ToString(): string {
-      file + "(" + NumUtils.IntToString(line) + "," + NumUtils.IntToString(column) + ")"
+      file + "(" + Str.of_int(line as int) + "," + Str.of_int(column as int) + ")"
     }
   }
 

--- a/src/AST/Names.dfy
+++ b/src/AST/Names.dfy
@@ -44,6 +44,15 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
       }
     }
 
+    function IsCompile(): bool {
+      match this {
+        case Anonymous => false
+        case Name(_, suffix) =>
+          var parts := Seq.Split('_', suffix);
+          (|parts| > 0 && parts[|parts| - 1] == "Compile") || parent.IsCompile()
+      }
+    }
+
     function ToSeq(): seq<Atom> {
       match this
         case Anonymous => []

--- a/src/AST/Names.dfy
+++ b/src/AST/Names.dfy
@@ -36,10 +36,11 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
 
     function IsInternal(): bool {
       match this {
-        case Anonymous => true
-        case Name(_, suffix) =>
+        case Anonymous => false
+        case Name(Anonymous, "_System") => true
+        case Name(parent, suffix) =>
           var parts := Seq.Split('_', suffix);
-          |parts| > 0 && parts[0] == "reveal"
+          (|parts| > 0 && parts[0] == "reveal") || parent.IsInternal()
       }
     }
 

--- a/src/AST/Names.dfy
+++ b/src/AST/Names.dfy
@@ -34,21 +34,25 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
       Seq.Flatten(Seq.Interleave(".", parts))
     }
 
-    function IsInternal(): bool {
+    function Any(P: Atom -> bool): bool {
       match this {
         case Anonymous => false
-        case Name(Anonymous, "_System") => true
         case Name(parent, suffix) =>
-          "reveal_" <= suffix || parent.IsInternal()
+          P(suffix) || parent.Any(P)
       }
     }
 
+    function IsInternal(): bool {
+      Any(suffix => || "reveal_" <= suffix
+                    || "_System" == suffix)
+    }
+
     function IsCompile(): bool {
-      match this {
-        case Anonymous => false
-        case Name(_, suffix) =>
-          "Compile_" <= suffix || parent.IsCompile()
-      }
+      Any(suffix =>
+        // TODO: this is a suffix, so we can't use <=.
+        // Is there a better way?
+        var parts := Seq.Split('_', suffix);
+        parts[|parts| - 1] == "Compile")
     }
 
     function ToSeq(): seq<Atom> {

--- a/src/AST/Names.dfy
+++ b/src/AST/Names.dfy
@@ -39,8 +39,7 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
         case Anonymous => false
         case Name(Anonymous, "_System") => true
         case Name(parent, suffix) =>
-          var parts := Seq.Split('_', suffix);
-          (|parts| > 0 && parts[0] == "reveal") || parent.IsInternal()
+          "reveal_" <= suffix || parent.IsInternal()
       }
     }
 
@@ -48,8 +47,7 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
       match this {
         case Anonymous => false
         case Name(_, suffix) =>
-          var parts := Seq.Split('_', suffix);
-          (|parts| > 0 && parts[|parts| - 1] == "Compile") || parent.IsCompile()
+          "Compile_" <= suffix || parent.IsCompile()
       }
     }
 

--- a/src/AST/Names.dfy
+++ b/src/AST/Names.dfy
@@ -1,6 +1,7 @@
 include "../Utils/Library.dfy"
 
 module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
+  import Utils.Lib.Seq
   import Utils.Lib.Set
   import C = Utils.Lib.Sort.Comparison
   import SeqCmp = Utils.Lib.Seq.Comparison
@@ -26,6 +27,20 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Names {
         case Anonymous => "_"
         case Name(Anonymous, suffix) => suffix
         case Name(parent, suffix) => parent.ToString() + "." + suffix
+    }
+
+    function ToDafnyName(): string {
+      var parts := Seq.Filter(this.ToSeq(), a => a !in {"_default", "_module"});
+      Seq.Flatten(Seq.Interleave(".", parts))
+    }
+
+    function IsInternal(): bool {
+      match this {
+        case Anonymous => true
+        case Name(_, suffix) =>
+          var parts := Seq.Split('_', suffix);
+          |parts| > 0 && parts[0] == "reveal"
+      }
     }
 
     function ToSeq(): seq<Atom> {

--- a/src/AST/Translator.Entity.dfy
+++ b/src/AST/Translator.Entity.dfy
@@ -261,17 +261,17 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Translator.Entity {
       Success([mod] + topDecls')
   }
 
-  function TranslateProgram(p: C.Program, skipCompile: bool): (exps: TranslationResult<E.Program>)
+  function TranslateProgram(p: C.Program, nameonly includeCompileModules: bool := true): (exps: TranslationResult<E.Program>)
     reads *
   {
     var moduleDefs := ListUtils.ToSeq(p.CompileModules);
     var entities :- Seq.MapResult(moduleDefs,
       (def: C.ModuleDefinition) reads * => TranslateModule(def));
     var flatEntities := Seq.Flatten(entities);
-    var inclEntities := if skipCompile then
-                          Seq.Filter(flatEntities, (e: E.Entity) => !e.ei.name.IsCompile())
+    var inclEntities := if includeCompileModules then
+                          flatEntities
                         else
-                          flatEntities;
+                          Seq.Filter(flatEntities, (e: E.Entity) => !e.ei.name.IsCompile());
     var names := Seq.Map((e: E.Entity) => e.ei.name, inclEntities);
     var topNames := Seq.Filter(names, (n:N.Name) => n.Name? && n.parent.Anonymous?);
     :- Need(forall nm <- topNames :: nm.ChildOf(N.Anonymous), Invalid("Malformed name at top level"));

--- a/src/AST/Translator.Entity.dfy
+++ b/src/AST/Translator.Entity.dfy
@@ -31,7 +31,7 @@ module {:options "-functionSyntax:4"} Bootstrap.AST.Translator.Entity {
     var filename := if tok.FileName == null then "<none>" else TypeConv.AsString(tok.FileName);
     var line := tok.Line;
     var col := tok.Column;
-    E.Location(filename, line as int, col as int)
+    E.Location(filename, line, col)
   }
 
   function TranslateAttributeName(s: string): E.AttributeName {

--- a/src/AST/Translator.Expressions.dfy
+++ b/src/AST/Translator.Expressions.dfy
@@ -249,7 +249,10 @@ module Bootstrap.AST.Translator.Expressions {
     decreases ASTHeight(obj), 3
   {
     var fname := TypeConv.AsString(fullName);
-    if obj.Resolved is C.StaticReceiverExpr then
+    if obj.Type == null then
+      // This occasionally happens, and causes obj.Resolved to trigger an assertion failure.
+      TranslateUnsupportedExpression(obj)
+    else if obj.Resolved is C.StaticReceiverExpr then
       Success(DE.Var(fname))
     else
       var obj :- TranslateExpression(obj);

--- a/src/Backends/CSharp/Compiler.dfy
+++ b/src/Backends/CSharp/Compiler.dfy
@@ -306,7 +306,7 @@ module Compiler {
     method Compile(dafnyProgram: CSharpDafnyASTModel.Program,
                    wr: ConcreteSyntaxTree) {
       var st := new CSharpDafnyInterop.SyntaxTreeAdapter(wr);
-      match Entity.TranslateProgram(dafnyProgram) {
+      match Entity.TranslateProgram(dafnyProgram, false) {
         case Success(translated) =>
           var lowered := EliminateNegatedBinops.Apply(translated);
 

--- a/src/Backends/CSharp/Compiler.dfy
+++ b/src/Backends/CSharp/Compiler.dfy
@@ -306,7 +306,7 @@ module Compiler {
     method Compile(dafnyProgram: CSharpDafnyASTModel.Program,
                    wr: ConcreteSyntaxTree) {
       var st := new CSharpDafnyInterop.SyntaxTreeAdapter(wr);
-      match Entity.TranslateProgram(dafnyProgram, false) {
+      match Entity.TranslateProgram(dafnyProgram, includeCompileModules := true) {
         case Success(translated) =>
           var lowered := EliminateNegatedBinops.Apply(translated);
 

--- a/src/Interop/CSharpAuditorInterop.dfy
+++ b/src/Interop/CSharpAuditorInterop.dfy
@@ -1,0 +1,12 @@
+include "CSharpDafnyInterop.dfy"
+include "CSharpInterop.dfy"
+
+module {:extern "Microsoft.Dafny.Compilers.SelfHosting.Auditor"} {:compile false} Bootstrap.Tools.AuditorExterns {
+  import System
+  import Microsoft
+
+  class {:compile false} Auditor {
+    static method {:extern} Error(reporter: Microsoft.Dafny.ErrorReporter, file: System.String, line: System.int32, col: System.int32, msg: System.String)
+    static method {:extern} Warning(reporter: Microsoft.Dafny.ErrorReporter, file: System.String, line: System.int32, col: System.int32, msg: System.String)
+  }
+}

--- a/src/Interop/CSharpInterop.cs
+++ b/src/Interop/CSharpInterop.cs
@@ -1,5 +1,8 @@
 #nullable enable
 using System.Numerics;
+using Dafny;
+using icharseq = Dafny.ISequence<char>;
+using charseq = Dafny.Sequence<char>;
 
 namespace CSharpInterop {
   public partial class ListUtils {
@@ -37,6 +40,12 @@ namespace CSharpInterop {
         b0 = f(x, b0);
       }
       return b0;
+    }
+  }
+
+  public partial class NumUtils {
+    public static icharseq IntToString(BigInteger n) {
+      return charseq.FromString(n.ToString());
     }
   }
 }

--- a/src/Interop/CSharpInterop.cs
+++ b/src/Interop/CSharpInterop.cs
@@ -42,10 +42,4 @@ namespace CSharpInterop {
       return b0;
     }
   }
-
-  public partial class NumUtils {
-    public static icharseq IntToString(BigInteger n) {
-      return charseq.FromString(n.ToString());
-    }
-  }
 }

--- a/src/Interop/CSharpInterop.dfy
+++ b/src/Interop/CSharpInterop.dfy
@@ -40,14 +40,4 @@ module {:extern "CSharpInterop"} Bootstrap.Interop.CSharpInterop {
       FoldR((t, s) => [t] + s, [], l)
     }
   }
-
-  class NumUtils {
-    constructor {:extern} () requires false // Prevent instantiation
-
-    static function method {:extern} IntToString(x: int): string
-
-    static function method AsInt32OrNegOne(x: int): System.int32 {
-      (if -0x8000_0000 <= x < 0x8000_0000 then x else -1) as System.int32
-    }
-  }
 }

--- a/src/Interop/CSharpInterop.dfy
+++ b/src/Interop/CSharpInterop.dfy
@@ -45,5 +45,9 @@ module {:extern "CSharpInterop"} Bootstrap.Interop.CSharpInterop {
     constructor {:extern} () requires false // Prevent instantiation
 
     static function method {:extern} IntToString(x: int): string
+
+    static function method AsInt32OrNegOne(x: int): System.int32 {
+      (if -0x8000_0000 <= x < 0x8000_0000 then x else -1) as System.int32
+    }
   }
 }

--- a/src/Interop/CSharpInterop.dfy
+++ b/src/Interop/CSharpInterop.dfy
@@ -40,4 +40,10 @@ module {:extern "CSharpInterop"} Bootstrap.Interop.CSharpInterop {
       FoldR((t, s) => [t] + s, [], l)
     }
   }
+
+  class NumUtils {
+    constructor {:extern} () requires false // Prevent instantiation
+
+    static function method {:extern} IntToString(x: int): string
+  }
 }

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -58,7 +58,7 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
   function AddAssumptions(e: Entity, assms: seq<Assumption>): seq<Assumption> {
     var tags := GetTags(e);
     if IsAssumption(tags) then
-      assms + [Assumption(e.ei.name.ToDafnyName(), tags)]
+      assms + [Assumption(e.ei.name.ToDafnyName(), e.ei.location, tags)]
     else
       assms
   }

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -85,7 +85,7 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
 
     method Audit(render: Report -> string, p: CSharpDafnyASTModel.Program) returns (r: string)
     {
-      var res := E.TranslateProgram(p, true);
+      var res := E.TranslateProgram(p, includeCompileModules := false);
       match res {
         case Success(p') =>
           var rpt := GenerateAuditReport(p'.registry);
@@ -112,7 +112,7 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
 
     method AuditWarnings(reporter: Microsoft.Dafny.ErrorReporter, p: CSharpDafnyASTModel.Program)
     {
-      var res := E.TranslateProgram(p, true);
+      var res := E.TranslateProgram(p, includeCompileModules := false);
       match res {
         case Success(p') =>
           var rpt := GenerateAuditReport(p'.registry);

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -70,7 +70,7 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
   }
 
   function FoldEntities<T(!new)>(f: (Entity, T) -> T, reg: Registry_, init: T): T {
-    var names := Seq.Filter(reg.SortedNames(), (n:Name) => !n.IsInternal());
+    var names := Seq.Filter(reg.SortedNames(), (n: Name) => !n.IsInternal());
     FoldL((a, n) requires reg.Contains(n) => f(reg.Get(n), a), init, names)
   }
 

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -78,7 +78,7 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
 
     method Audit(render: Report -> string, p: CSharpDafnyASTModel.Program) returns (r: string)
     {
-      var res := E.TranslateProgram(p);
+      var res := E.TranslateProgram(p, true);
       match res {
         case Success(p') =>
           var rpt := GenerateAuditReport(p'.registry);

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -58,13 +58,13 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
   function AddAssumptions(e: Entity, assms: seq<Assumption>): seq<Assumption> {
     var tags := GetTags(e);
     if IsAssumption(tags) then
-      assms + [Assumption(e.ei.name.ToString(), tags)]
+      assms + [Assumption(e.ei.name.ToDafnyName(), tags)]
     else
       assms
   }
 
   function FoldEntities<T(!new)>(f: (Entity, T) -> T, reg: Registry_, init: T): T {
-    var names := reg.SortedNames();
+    var names := Seq.Filter(reg.SortedNames(), (n:Name) => !n.IsInternal());
     FoldL((a, n) requires reg.Contains(n) => f(reg.Get(n), a), init, names)
   }
 

--- a/src/Tools/Auditor/Auditor.dfy
+++ b/src/Tools/Auditor/Auditor.dfy
@@ -123,8 +123,8 @@ module {:extern "Bootstrap.Tools.Auditor"} {:options "-functionSyntax:4"} Bootst
             for j := 0 to |descs| {
               var desc := descs[j];
               var msg := AssumptionWarning(a, desc);
-              var line := NumUtils.AsInt32OrNegOne(a.location.line);
-              var col := NumUtils.AsInt32OrNegOne(a.location.column);
+              var line := a.location.line;
+              var col := a.location.column;
               AuditorExterns.Auditor.Warning(reporter, StringUtils.ToCString(loc.file),
                                           line, col, StringUtils.ToCString(msg));
             }

--- a/src/Tools/Auditor/EntryPoint.cs
+++ b/src/Tools/Auditor/EntryPoint.cs
@@ -35,6 +35,25 @@ public class Auditor : Plugins.Rewriter {
     return templateText.Replace("{{TABLE}}", table.ToString());
   }
 
+  // TODO: potentially move this to ErrorReporter as a non-static method
+  internal static void Warning(ErrorReporter reporter, string filename, int line, int col, string msg) {
+    var tok = new Token(line, col);
+    tok.Filename = filename;
+    // TODO: is this the right source? This is technically a rewriter
+    // plugin, but it's not doing any rewriting. Maybe we should add
+    // support for resolver plugins and change this to be one?
+    reporter.Warning(MessageSource.Rewriter, tok, msg);
+  }
+
+  internal static void Error(ErrorReporter reporter, string filename, int line, int col, string msg) {
+    var tok = new Token(line, col);
+    tok.Filename = filename;
+    // TODO: is this the right source? This is technically a rewriter
+    // plugin, but it's not doing any rewriting. Maybe we should add
+    // support for resolver plugins and change this to be one?
+    reporter.Error(MessageSource.Rewriter, tok, msg);
+  }
+
   public override void PostResolve(Program program) {
     string? filename = null;
     Format format = Format.Text;
@@ -58,15 +77,15 @@ public class Auditor : Plugins.Rewriter {
       }
     }
 
-    var text = format switch {
-      Format.HTML => GenerateHTMLReport(program),
-      Format.Markdown => auditor.AuditMarkdown(program).ToString(),
-      Format.Text => auditor.AuditText(program).ToString(),
-    };
-
     if (filename is null) {
-      Console.WriteLine(text);
+      auditor.AuditWarnings(Reporter, program);
     } else {
+      var text = format switch {
+        Format.HTML => GenerateHTMLReport(program),
+        Format.Markdown => auditor.AuditMarkdown(program).ToString(),
+        Format.Text => auditor.AuditText(program).ToString(),
+      };
+
       File.WriteAllText(filename, text);
     }
   }

--- a/src/Tools/Auditor/EntryPoint.cs
+++ b/src/Tools/Auditor/EntryPoint.cs
@@ -37,7 +37,7 @@ public class Auditor : Plugins.Rewriter {
 
   public override void PostResolve(Program program) {
     string? filename = null;
-    Format format = Format.Markdown;
+    Format format = Format.Text;
     string[] args = AuditorConfiguration.args;
 
     if (args.Count() > 1) {

--- a/src/Tools/Auditor/README.rst
+++ b/src/Tools/Auditor/README.rst
@@ -44,4 +44,15 @@ From the top level of this repository, run the following.
   ./dafny/Scripts/dafny /plugin:src/Tools/Auditor/bin/Debug/net6.0/DafnyAuditor.dll,<output file> /compile:0 /noVerify <input files>
 
 Here, ``<input files>`` should be one or more Dafny source files, and
-``<output file>`` indicates where to write the report. The
+``<output file>`` indicates where to write the report. The extension of
+the output file indicates what format to use. The following are supported:
+
+``.html``
+  Format in HTML with sortable tables.
+``.md``
+  Format as a Markdown table.
+``.txt``
+  Format as plain text for a human reader.
+
+If an output file is not provided, the report is sent to the console in
+the form of a list of warnings.

--- a/src/Tools/Auditor/README.rst
+++ b/src/Tools/Auditor/README.rst
@@ -1,0 +1,47 @@
+=============
+Dafny Auditor
+=============
+
+A tool to audit Dafny programs and report on assumptions contained
+within.
+
+Overview
+========
+
+It currently detects the following forms of assumption:
+
+* Anything marked with the ``{:axiom}`` attribute.
+
+* Declarations with at least one ``ensures`` clauses that
+
+  * lack a body, or
+
+  * are marked with the ``{:extern}`` attribute.
+
+* Explicit ``assume`` statements.
+
+In the future, it will detect additional constructs that introduce
+assumptions and integrate the results of other analyses.
+
+Building
+========
+
+From the top level of this repository, run the following.
+
+.. code-block:: shell
+
+  git clone https://github.com/dafny-lang/dafny
+  (cd dafny && git checkout compiler-bootstrap)
+  DAFNY_ROOT=dafny make auditor
+
+Usage
+=====
+
+From the top level of this repository, run the following.
+
+.. code-block:: shell
+
+  ./dafny/Scripts/dafny /plugin:src/Tools/Auditor/bin/Debug/net6.0/DafnyAuditor.dll,<output file> /compile:0 /noVerify <input files>
+
+Here, ``<input files>`` should be one or more Dafny source files, and
+``<output file>`` indicates where to write the report. The

--- a/src/Tools/Auditor/README.rst
+++ b/src/Tools/Auditor/README.rst
@@ -31,8 +31,8 @@ From the top level of this repository, run the following.
 .. code-block:: shell
 
   git clone https://github.com/dafny-lang/dafny
-  (cd dafny && git checkout compiler-bootstrap)
-  DAFNY_ROOT=dafny make auditor
+  (cd dafny && git checkout compiler-bootstrap && make exe)
+  DAFNY_ROOT=$(pwd)/dafny make clean auditor
 
 Usage
 =====
@@ -52,7 +52,8 @@ the output file indicates what format to use. The following are supported:
 ``.md``
   Format as a Markdown table.
 ``.txt``
-  Format as plain text for a human reader.
+  Format as plain text for a human reader (currently a list of
+  warnings).
 
 If an output file is not provided, the report is sent to the console in
 the form of a list of warnings.

--- a/src/Tools/Auditor/README.rst
+++ b/src/Tools/Auditor/README.rst
@@ -41,7 +41,7 @@ From the top level of this repository, run the following.
 
 .. code-block:: shell
 
-  ./dafny/Scripts/dafny /plugin:src/Tools/Auditor/bin/Debug/net6.0/DafnyAuditor.dll,<output file> /compile:0 /noVerify <input files>
+   ./dafny/Scripts/dafny /plugin:src/Tools/Auditor/bin/Debug/net6.0/DafnyAuditor.dll,<output file> /compile:0 /noVerify <input files>
 
 Here, ``<input files>`` should be one or more Dafny source files, and
 ``<output file>`` indicates where to write the report. The extension of

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -78,34 +78,33 @@ module Bootstrap.Tools.AuditReport {
      if b then [elt] else []
   }
 
-  // TODO: improve these descriptions
   function method AssumptionDescription(ts: set<Tag>): seq<(string, string)> {
     MaybeElt(IsCallable in ts && MissingBody in ts && IsGhost in ts,
-      ("Function or lemma has no body.",
-       "Provide a body or add {:axiom}.")) +
+      ("Ghost declaration has no body.",
+       "Provide a body or add `{:axiom}`.")) +
     MaybeElt(IsCallable in ts && MissingBody in ts && !(IsGhost in ts),
-      ("Callable definition has no body.",
-       "Provide a body or add {:axiom}.")) +
+      ("Compiled declaration has no body.",
+       "Provide a body or add `{:axiom}`.")) +
     MaybeElt(HasExternAttribute in ts && HasRequiresClause in ts,
-      ("Extern symbol with precondition.",
+      ("Declaration with `{:extern}` has precondition.",
        "Extensively test client code.")) +
     MaybeElt(HasExternAttribute in ts && HasEnsuresClause in ts,
-      ("Extern symbol with postcondition.",
-       "Provide a model or a test case, or both.")) +
+      ("Declaration with `{:extern}` has postcondition.",
+       "Extensively test against external code.")) +
        /*
     MaybeElt(IsSubsetType in ts && MissingWitness in ts,
       ("Subset type has no witness and could be empty.",
        "Provide a witness.")) +
        */
     MaybeElt(HasAxiomAttribute in ts,
-      ("Has explicit `{:axiom}` attribute.",
-       "Attempt to provide a proof or model.")) +
+      ("Declaration has explicit `{:axiom}` attribute.",
+       "Attempt to provide a proof or test.")) +
     MaybeElt(MayNotTerminate in ts,
-      ("May not terminate (uses `decreases *`).",
+      ("Method may not terminate (uses `decreases *`).",
        "Provide a valid `decreases` clause.")) +
     MaybeElt(HasAssumeInBody in ts,
-      ("Has `assume` statement in body.",
-      "Try to replace with `assert` and prove or add {:axiom}."))
+      ("Definition has `assume` statement in body.",
+      "Try to replace with `assert` and prove or add `{:axiom}`."))
   }
 
   lemma AllAssumptionsDescribed(ts: set<Tag>)

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -1,6 +1,8 @@
+include "../../AST/Entities.dfy"
 include "../../Utils/Library.dfy"
 
-module AuditReport {
+module Bootstrap.Tools.AuditReport {
+  import opened AST.Entities
   import opened Utils.Lib.Seq
 
 /// ## Data types for report
@@ -40,7 +42,7 @@ module AuditReport {
     }
 
   datatype Assumption =
-    Assumption(name: string, tags: set<Tag>)
+    Assumption(name: string, location: Location, tags: set<Tag>)
 
   datatype Report =
     Report(assumptions: seq<Assumption>)

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -5,7 +5,7 @@ module Bootstrap.Tools.AuditReport {
   import opened AST.Entities
   import opened Utils.Lib.Seq
 
-/// ## Data types for report
+  /// ## Data types for report
 
   datatype Tag =
     | IsGhost
@@ -49,7 +49,7 @@ module Bootstrap.Tools.AuditReport {
 
   const EmptyReport := Report([])
 
-/// ## Tag categorization
+  /// ## Tag categorization
 
   predicate method IsAssumption(ts: set<Tag>) {
     // This seems to be of little value at the moment
@@ -68,7 +68,7 @@ module Bootstrap.Tools.AuditReport {
     || HasAssumeInBody in ts
   }
 
-/// ## Report rendering
+  /// ## Report rendering
 
   function method BoolYN(b: bool): string {
     if b then "Y" else "N"

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -5,7 +5,7 @@ module Bootstrap.Tools.AuditReport {
   import opened AST.Entities
   import opened Utils.Lib.Seq
 
-  /// ## Data types for report
+/// ## Data types for report
 
   datatype Tag =
     | IsGhost

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -156,10 +156,13 @@ module Bootstrap.Tools.AuditReport {
     FoldL((s, a) => s + RenderAssumptionHTML(a) + "\n", header, r.assumptions)
   }
 
+  function method AssumptionWarning(a: Assumption, desc: (string, string)): string {
+      a.location.ToString() + ": " + a.name + ": " + desc.0 + " Possible mitigation: " + desc.1
+  }
+
   function method RenderAssumptionText(a: Assumption): string {
     var descs := AssumptionDescription(a.tags);
-    var lines := Map((desc: (string, string)) =>
-      a.location.ToString() + ": " + a.name + ": " + desc.0 + " Possible mitigation: " + desc.1, descs);
+    var lines := Map((desc: (string, string)) => AssumptionWarning(a, desc), descs);
     Flatten(Seq.Interleave("\n", lines))
   }
 

--- a/src/Tools/Auditor/Report.dfy
+++ b/src/Tools/Auditor/Report.dfy
@@ -49,7 +49,7 @@ module Bootstrap.Tools.AuditReport {
 
   const EmptyReport := Report([])
 
-  /// ## Tag categorization
+/// ## Tag categorization
 
   predicate method IsAssumption(ts: set<Tag>) {
     // This seems to be of little value at the moment
@@ -68,7 +68,7 @@ module Bootstrap.Tools.AuditReport {
     || HasAssumeInBody in ts
   }
 
-  /// ## Report rendering
+/// ## Report rendering
 
   function method BoolYN(b: bool): string {
     if b then "Y" else "N"
@@ -157,12 +157,13 @@ module Bootstrap.Tools.AuditReport {
   }
 
   function method AssumptionWarning(a: Assumption, desc: (string, string)): string {
-      a.location.ToString() + ": " + a.name + ": " + desc.0 + " Possible mitigation: " + desc.1
+      a.name + ": " + desc.0 + " Possible mitigation: " + desc.1
   }
 
   function method RenderAssumptionText(a: Assumption): string {
     var descs := AssumptionDescription(a.tags);
-    var lines := Map((desc: (string, string)) => AssumptionWarning(a, desc), descs);
+    var lines := Map((desc: (string, string)) =>
+      a.location.ToString() + ": " + AssumptionWarning(a, desc), descs);
     Flatten(Seq.Interleave("\n", lines))
   }
 

--- a/src/Tools/Auditor/ReportTest.dfy
+++ b/src/Tools/Auditor/ReportTest.dfy
@@ -1,30 +1,32 @@
 include "Report.dfy"
 
-module AuditReportTest {
+module Bootstrap.Tools.AuditReportTest {
 
   import opened AuditReport
+  import opened AST.Entities
 
   method Main() {
+    var loc := Location("File.dfy", 0, 0);
     var rpt := Report([
-      Assumption("MinusBv8NoBody",
+      Assumption("MinusBv8NoBody", loc,
         {IsCallable, IsGhost, MissingBody, HasEnsuresClause}),
-      Assumption("LeftShiftBV128",
+      Assumption("LeftShiftBV128", loc,
         {IsCallable, IsGhost, MissingBody, HasEnsuresClause, HasAxiomAttribute}),
-      Assumption("MinusBv8Assume",
+      Assumption("MinusBv8Assume", loc,
         {IsCallable, IsGhost, HasEnsuresClause, HasAssumeInBody}),
-      Assumption("GenerateBytes",
+      Assumption("GenerateBytes", loc,
         {IsCallable, HasExternAttribute, HasEnsuresClause, MissingBody}),
-      Assumption("GenerateBytesWithModel",
+      Assumption("GenerateBytesWithModel", loc,
         {IsCallable, HasExternAttribute, HasEnsuresClause}),
-      Assumption("GenerateBytesWrapper",
+      Assumption("GenerateBytesWrapper", loc,
         {IsCallable, HasExternAttribute, HasEnsuresClause, HasAssumeInBody})
       /*
-      Assumption("emptyType",
+      Assumption("emptyType", loc,
         {IsSubsetType, MissingWitness})
         */
       // This doesn't pass IsAsssumption
       /*
-      Assumption("WhoKnows",
+      Assumption("WhoKnows", loc,
         {IsCallable, IsGhost, HasNoBody})
         */
       ]);

--- a/src/Tools/Auditor/ReportTest.dfy
+++ b/src/Tools/Auditor/ReportTest.dfy
@@ -7,19 +7,21 @@ module AuditReportTest {
   method Main() {
     var rpt := Report([
       Assumption("MinusBv8NoBody",
-        {IsCallable, IsGhost, HasNoBody, HasEnsuresClause}),
+        {IsCallable, IsGhost, MissingBody, HasEnsuresClause}),
       Assumption("LeftShiftBV128",
-        {IsCallable, IsGhost, HasNoBody, HasEnsuresClause, HasAxiomAttribute}),
+        {IsCallable, IsGhost, MissingBody, HasEnsuresClause, HasAxiomAttribute}),
       Assumption("MinusBv8Assume",
         {IsCallable, IsGhost, HasEnsuresClause, HasAssumeInBody}),
       Assumption("GenerateBytes",
-        {IsCallable, HasExternAttribute, HasEnsuresClause, HasNoBody}),
+        {IsCallable, HasExternAttribute, HasEnsuresClause, MissingBody}),
       Assumption("GenerateBytesWithModel",
         {IsCallable, HasExternAttribute, HasEnsuresClause}),
       Assumption("GenerateBytesWrapper",
-        {IsCallable, HasExternAttribute, HasEnsuresClause, HasAssumeInBody}),
+        {IsCallable, HasExternAttribute, HasEnsuresClause, HasAssumeInBody})
+      /*
       Assumption("emptyType",
-        {IsSubsetType, HasNoWitness})
+        {IsSubsetType, MissingWitness})
+        */
       // This doesn't pass IsAsssumption
       /*
       Assumption("WhoKnows",

--- a/src/Tools/Auditor/assets/template.html
+++ b/src/Tools/Auditor/assets/template.html
@@ -17,6 +17,9 @@
       vertical-align: middle;
     }
     .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+    table tr:nth-child(odd) td {
+      background-color: #BBBBBB;
+    }
   </style>
   <link rel="stylesheet" href="assets/style.css" />
 </head>


### PR DESCRIPTION
This adds a README for the auditor and references to that README and the auditor in general in the top-level README.

It also makes various changes to the auditor output, including:

* Skipping included modules, _Compile modules, and internal names
* Formatting names more readably
* Using one row per issue in tables (rather than one row per name)
* Supporting warning-like output (used when no file name is specified)
* Improving the text of some issue descriptions
* Coloring alternate table rows differently in the HTML output
* Generating proper warnings when run with no file name

Fixes #13
Fixes #19