### PR TITLE
Use NuGet version of Dafny for auditor

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -67,6 +67,7 @@ repl_dll := $(repl)/publish/REPL.dll
 validator_dll := $(validator)/publish/Validator.dll
 auditor_dll := $(auditor)/publish/DafnyAuditor.dll
 dlls := $(csharp_dll) $(repl_dll) $(auditor_dll) $(validator_dll)
+publish_dirs := $(csharp)/publish $(repl)/publish $(validator)/publish $(auditor)/publish
 
 # Entry points
 dfy_entry_points := $(repl)/Repl.dfy $(csharp)/Compiler.dfy $(auditor)/Auditor.dfy $(validator)/Validator.dfy
@@ -161,4 +162,4 @@ verify: $(dfy_models)
 build: $(dlls)
 
 clean:
-	rm -fr $(cs_entry_points) $(dafny_model) $(cs_objs)
+	rm -fr $(cs_entry_points) $(dafny_model) $(cs_objs) $(publish_dirs)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -62,10 +62,10 @@ validator := src/Tools/Validator
 auditor := src/Tools/Auditor
 
 # Binaries
-csharp_dll := $(csharp)/output/CSharpCompiler.dll
-repl_dll := $(repl)/output/REPL.dll
-validator_dll := $(validator)/output/Validator.dll
-auditor_dll := $(auditor)/output/DafnyAuditor.dll
+csharp_dll := $(csharp)/publish/CSharpCompiler.dll
+repl_dll := $(repl)/publish/REPL.dll
+validator_dll := $(validator)/publish/Validator.dll
+auditor_dll := $(auditor)/publish/DafnyAuditor.dll
 dlls := $(csharp_dll) $(repl_dll) $(auditor_dll) $(validator_dll)
 
 # Entry points
@@ -114,13 +114,13 @@ $(auditor)/Auditor.cs: $(auditor)/Auditor.dfy $(dfy_models) $(dfy_interop) $(Daf
 
 # Compile the resulting C# code
 $(csharp_dll): $(csharp)/Compiler.cs $(cs_interop)
-	dotnet publish -o $(csharp)/output $(csharp)/CSharpCompiler.csproj
+	dotnet publish -o $(csharp)/publish $(csharp)/CSharpCompiler.csproj
 
 $(validator_dll): $(validator)/Validator.cs $(validator)/EntryPoint.cs $(cs_interop)
-	dotnet publish -o $(validator)/output $(validator)/Validator.csproj
+	dotnet publish -o $(validator)/publish $(validator)/Validator.csproj
 
 $(auditor_dll): $(auditor)/Auditor.cs $(auditor)/EntryPoint.cs $(cs_interop)
-	dotnet publish -o $(auditor)/output $(auditor)/DafnyAuditor.csproj
+	dotnet publish -o $(auditor)/publish $(auditor)/DafnyAuditor.csproj
 
 # Run it on tests
 test/%.cs: test/%.dfy $(csharp_dll) $(DafnyRuntime)
@@ -138,7 +138,7 @@ $(repl)/Repl.cs: $(repl)/Repl.dfy $(dafny_model) $(dfy_models) $(dfy_interop) $(
 	rm "$@.bak"
 
 $(repl_dll): $(repl)/Repl.cs $(repl)/REPLInterop.cs $(cs_interop)
-	dotnet publish -o $(repl)/output --configuration=Release $(repl)/REPL.csproj
+	dotnet publish -o $(repl)/publish --configuration=Release $(repl)/REPL.csproj
 
 # Entry points
 # ============

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ DafnyAST = $(dafny_Source)/Dafny/AST/DafnyAst
 DafnyRuntime := $(dafny_Source)/DafnyRuntime/DafnyRuntime.cs
 
 DAFNY ?= dotnet run --project $(DafnyDriver).csproj $(DAFNY_DOTNET_RUN_FLAGS) --
-dafny_codegen := $(DAFNY) -spillTargetCode:3 -compile:0 -noVerify -useRuntimeLib
+dafny_codegen := $(DAFNY) -spillTargetCode:3 -compile:0 -noVerify
 dafny_typecheck := $(DAFNY) -dafnyVerify:0
 dafny_verify := $(DAFNY) -compile:0  -trace -verifyAllModules -showSnippets:1 -vcsCores:8
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ DafnyAST = $(dafny_Source)/Dafny/AST/DafnyAst
 DafnyRuntime := $(dafny_Source)/DafnyRuntime/DafnyRuntime.cs
 
 DAFNY ?= dotnet run --project $(DafnyDriver).csproj $(DAFNY_DOTNET_RUN_FLAGS) --
-dafny_codegen := $(DAFNY) -spillTargetCode:3 -compile:0 -noVerify
+dafny_codegen := $(DAFNY) -spillTargetCode:3 -compile:0 -noVerify -useRuntimeLib
 dafny_typecheck := $(DAFNY) -dafnyVerify:0
 dafny_verify := $(DAFNY) -compile:0  -trace -verifyAllModules -showSnippets:1 -vcsCores:8
 
@@ -62,10 +62,10 @@ validator := src/Tools/Validator
 auditor := src/Tools/Auditor
 
 # Binaries
-csharp_dll := $(csharp)/bin/Debug/net6.0/CSharpCompiler.dll
-repl_dll := $(repl)/bin/Release/net6.0/REPL.dll
-validator_dll := $(validator)/bin/Debug/net6.0/Validator.dll
-auditor_dll := $(auditor)/bin/Debug/net6.0/DafnyAuditor.dll
+csharp_dll := $(csharp)/output/CSharpCompiler.dll
+repl_dll := $(repl)/output/REPL.dll
+validator_dll := $(validator)/output/Validator.dll
+auditor_dll := $(auditor)/output/DafnyAuditor.dll
 dlls := $(csharp_dll) $(repl_dll) $(auditor_dll) $(validator_dll)
 
 # Entry points
@@ -114,13 +114,13 @@ $(auditor)/Auditor.cs: $(auditor)/Auditor.dfy $(dfy_models) $(dfy_interop) $(Daf
 
 # Compile the resulting C# code
 $(csharp_dll): $(csharp)/Compiler.cs $(cs_interop)
-	dotnet build $(csharp)/CSharpCompiler.csproj
+	dotnet publish -o $(csharp)/output $(csharp)/CSharpCompiler.csproj
 
 $(validator_dll): $(validator)/Validator.cs $(validator)/EntryPoint.cs $(cs_interop)
-	dotnet build $(validator)/Validator.csproj
+	dotnet publish -o $(validator)/output $(validator)/Validator.csproj
 
 $(auditor_dll): $(auditor)/Auditor.cs $(auditor)/EntryPoint.cs $(cs_interop)
-	dotnet build $(auditor)/DafnyAuditor.csproj
+	dotnet publish -o $(auditor)/output $(auditor)/DafnyAuditor.csproj
 
 # Run it on tests
 test/%.cs: test/%.dfy $(csharp_dll) $(DafnyRuntime)
@@ -138,7 +138,7 @@ $(repl)/Repl.cs: $(repl)/Repl.dfy $(dafny_model) $(dfy_models) $(dfy_interop) $(
 	rm "$@.bak"
 
 $(repl_dll): $(repl)/Repl.cs $(repl)/REPLInterop.cs $(cs_interop)
-	dotnet build --configuration=Release $(repl)/REPL.csproj
+	dotnet publish -o $(repl)/output --configuration=Release $(repl)/REPL.csproj
 
 # Entry points
 # ============

--- a/src/Tools/Auditor/DafnyAuditor.csproj
+++ b/src/Tools/Auditor/DafnyAuditor.csproj
@@ -18,7 +18,7 @@
     <!-- TODO: it would be nice to use this eventually, and no longer
     need a Makefile -->
     <!-- <PackageReference Include="dafny.msbuild" Version="1.0.0" /> -->
-    <PackageReference Include="DafnyPipeline" Version="3.8.1.40901" />
+    <PackageReference Include="DafnyPipeline" Version="3.9.0.41003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/Auditor/DafnyAuditor.csproj
+++ b/src/Tools/Auditor/DafnyAuditor.csproj
@@ -1,21 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <AssemblyName>DafnyAuditor</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DAFNY_ROOT Condition="'$(DAFNY_ROOT)' == ''">..\..\..\..\</DAFNY_ROOT>
-  </PropertyGroup>
-
-  <!-- TODO: get DafnyPipeline from NuGet when we can -->
   <ItemGroup>
-    <ProjectReference Include="$(DAFNY_ROOT)\Source\Dafny\DafnyPipeline.csproj" />
     <Compile Include="..\..\Interop\CSharpInterop.cs" />
     <Compile Include="..\..\Interop\CSharpDafnyInterop.cs" />
     <Compile Include="..\..\Interop\CSharpDafnyASTInterop.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- TODO: it would be nice to use this eventually, and no longer
+    need a Makefile -->
+    <!-- <PackageReference Include="dafny.msbuild" Version="1.0.0" /> -->
+    <PackageReference Include="DafnyPipeline" Version="3.8.1.40901" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/Auditor/DafnyAuditor.csproj
+++ b/src/Tools/Auditor/DafnyAuditor.csproj
@@ -19,6 +19,7 @@
     need a Makefile -->
     <!-- <PackageReference Include="dafny.msbuild" Version="1.0.0" /> -->
     <PackageReference Include="DafnyPipeline" Version="3.9.0.41003" />
+    <PackageReference Include="DafnyRuntime" Version="3.9.0.41003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/Auditor/DafnyAuditor.csproj
+++ b/src/Tools/Auditor/DafnyAuditor.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <VersionPrefix>3.9.0.41003</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR changes the auditor to use the released versions of `DafnyPipeline` and `DafnyRuntime` from NuGet. It also makes the plugin easier to use with an external Dafny build by using `dotnet publish` rather than just `dotnet build`. In the process, it adapts the other tools to use `dotnet publish`, as well, as it seems like a slightly cleaner approach for them, too.

Fixes #16 